### PR TITLE
Adding support for lazily and "drunkenly" ordered lists

### DIFF
--- a/t/markup/standard/list.t
+++ b/t/markup/standard/list.t
@@ -914,4 +914,175 @@ EOF
     );
 }
 
+{
+    my $text = <<'EOF';
+1. First
+1. Second
+1. Third
+EOF
+
+    my $expect = [
+        {
+            type => 'ordered_list',
+        },
+        [
+            {
+                type   => 'list_item',
+                bullet => '1.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "First\n",
+                }
+            ],
+            {
+                type   => 'list_item',
+                bullet => '2.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "Second\n",
+                },
+            ],
+            {
+                type   => 'list_item',
+                bullet => '3.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "Third\n",
+                },
+            ],
+        ],
+    ];
+
+    parse_ok( $text, $expect, 'lazily numbered ordered list' );
+}
+
+{
+    my $text = <<'EOF';
+042. First
+6. Second
+10. Third
+EOF
+
+    my $expect = [
+        {
+            type => 'ordered_list',
+        },
+        [
+            {
+                type   => 'list_item',
+                bullet => '1.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "First\n",
+                }
+            ],
+            {
+                type   => 'list_item',
+                bullet => '2.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "Second\n",
+                },
+            ],
+            {
+                type   => 'list_item',
+                bullet => '3.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "Third\n",
+                },
+            ],
+        ],
+    ];
+
+    parse_ok( $text, $expect, 'drunkenly numbered ordered list' );
+}
+
+{
+    my $text = <<'EOF';
+1. ordered
+5. #2
+    1. nested
+    1. #2
+1. and ordered again
+EOF
+
+    my $expect = [
+        {
+            type => 'ordered_list',
+        },
+        [
+            {
+                type   => 'list_item',
+                bullet => '1.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "ordered\n",
+                }
+            ],
+            {
+                type   => 'list_item',
+                bullet => '2.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "#2\n",
+                },
+                { type => 'ordered_list' },
+                [
+                    {
+                        type   => 'list_item',
+                        bullet => '1.',
+                    },
+                    [
+                        {
+                            type => 'text',
+                            text => "nested\n",
+                        },
+                    ],
+                    {
+                        type   => 'list_item',
+                        bullet => '2.',
+                    },
+                    [
+                        {
+                            type => 'text',
+                            text => "#2\n",
+                        },
+                    ],
+                ],
+            ],
+            {
+                type   => 'list_item',
+                bullet => '3.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "and ordered again\n",
+                },
+            ],
+        ],
+    ];
+
+    parse_ok( $text, $expect, 'drunk and lazily numbered ordered lists, nested' );
+}
+
+
+
 done_testing();


### PR DESCRIPTION
This patch adds support (and tests) for lazy lists, where every line is led by "1.", as well as (for lack of a better term) drunken lists, where the numbers have no need for either order or contiguousness, as long as they're whole numbers. Both styles are explicitly blessed by the core Markdown spec (http://daringfireball.net/projects/markdown/syntax#list).
