### PR TITLE
Ordered unordered lists issue

### DIFF
--- a/lib/Markdent/Dialect/GitHub/BlockParser.pm
+++ b/lib/Markdent/Dialect/GitHub/BlockParser.pm
@@ -19,7 +19,7 @@ around _possible_block_matches => sub {
     my $self = shift;
 
     my @look_for = $self->$orig();
-    insert_after_string 'list', 'fenced_code_block', @look_for;
+    insert_after_string 'unordered_list', 'fenced_code_block', @look_for;
 
     return @look_for;
 };

--- a/lib/Markdent/Dialect/Theory/BlockParser.pm
+++ b/lib/Markdent/Dialect/Theory/BlockParser.pm
@@ -45,10 +45,10 @@ around _possible_block_matches => sub {
     return @look_for if $self->_list_level();
 
     if ( $self->_in_table() ) {
-        insert_after_string 'list', 'table_cell', @look_for;
+        insert_after_string 'unordered_list', 'table_cell', @look_for;
     }
     else {
-        insert_after_string 'list', 'table', @look_for;
+        insert_after_string 'unordered_list', 'table', @look_for;
     }
 
     return @look_for;

--- a/lib/Markdent/Parser/BlockParser.pm
+++ b/lib/Markdent/Parser/BlockParser.pm
@@ -74,9 +74,9 @@ has _list_bullet_type => (
     traits => [ 'String' ],
     is => 'rw',
     isa => 'Str',
-    default => "",
+    default => q{},
     init_arg => undef,
-    writer => "_set_list_bullet_type",
+    writer => '_set_list_bullet_type',
 );
 
 sub parse_document {
@@ -553,11 +553,11 @@ sub _bullet_re {
     my ( $self ) = @_;
 
     my $re;
-    my $type = $self->_list_bullet_type || "";
-    if ( $type eq "ordered" ) {
+    my $type = $self->_list_bullet_type || q{};
+    if ( $type eq 'ordered' ) {
         $re = qr/\d+\./;
     }
-    elsif ( $type eq "unordered" ) {
+    elsif ( $type eq 'unordered' ) {
         $re = qr/[\+\*\-]/;
     }
     else {
@@ -604,11 +604,12 @@ sub _list_re {
     return $list;
 }
 
+## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
 sub _match_ordered_list {
     my $self = shift;
     my $text = shift;
 
-    $self->_set_list_bullet_type("ordered");
+    $self->_set_list_bullet_type('ordered');
     return $self->_match_list( $text );
 }
 
@@ -616,11 +617,10 @@ sub _match_unordered_list {
     my $self = shift;
     my $text = shift;
 
-    $self->_set_list_bullet_type("unordered");
+    $self->_set_list_bullet_type('unordered');
     return $self->_match_list( $text );
 }
 
-## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
 sub _match_list {
     my $self = shift;
     my $text = shift;

--- a/t/markup/standard/list.t
+++ b/t/markup/standard/list.t
@@ -1056,4 +1056,72 @@ EOF
     );
 }
 
+{
+    my $text = <<'EOF';
+1. first
+2. second
+
+* the next
+* list
+EOF
+
+    my $expect = [
+        {
+            type => 'ordered_list',
+        },
+        [
+            {
+                type   => 'list_item',
+                bullet => '1.',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "first\n",
+                }
+            ],
+            {
+                type   => 'list_item',
+                bullet => '2.',
+            },
+            [
+                {
+                    type => "text",
+                    text => "second\n",
+                }
+            ],
+        ],
+        {
+            type => 'unordered_list',
+        },
+        [
+            {
+                type   => 'list_item',
+                bullet => '*',
+            },
+            [
+                {
+                    type => 'text',
+                    text => "the next\n",
+                }
+            ],
+            {
+                type   => 'list_item',
+                bullet => '*',
+            },
+            [
+                {
+                    type => "text",
+                    text => "list\n",
+                }
+            ],
+        ]
+    ];
+
+    parse_ok(
+        $text, $expect,
+        'different types list go one by one'
+    );
+}
+
 done_testing();

--- a/t/markup/standard/list.t
+++ b/t/markup/standard/list.t
@@ -1086,7 +1086,7 @@ EOF
             },
             [
                 {
-                    type => "text",
+                    type => 'text',
                     text => "second\n",
                 }
             ],
@@ -1111,7 +1111,7 @@ EOF
             },
             [
                 {
-                    type => "text",
+                    type => 'text',
                     text => "list\n",
                 }
             ],

--- a/t/mdtest-data/Ordered and unordered lists.text
+++ b/t/mdtest-data/Ordered and unordered lists.text
@@ -88,7 +88,7 @@ Multiple paragraphs:
 
 	Item 2. graf two. The quick brown fox jumped over the lazy dog's
 	back.
-	
+
 2.	Item 2.
 
 3.	Item 3.
@@ -129,3 +129,11 @@ This was an error in Markdown 1.0.1:
 	*	sub
 
 	that
+
+
+Ordered and unodered list one by one
+
+1. First
+2. Second
+* I'm the next
+* list element

--- a/t/mdtest-data/Ordered and unordered lists.text
+++ b/t/mdtest-data/Ordered and unordered lists.text
@@ -135,5 +135,6 @@ Ordered and unodered list one by one
 
 1. First
 2. Second
+
 * I'm the next
 * list element

--- a/t/mdtest-data/Ordered and unordered lists.xhtml
+++ b/t/mdtest-data/Ordered and unordered lists.xhtml
@@ -146,3 +146,14 @@ back.</p></li>
 
 <p>that</p></li>
 </ul>
+
+<p>Ordered and unodered list one by one</p>
+
+<ol>
+<li>First</li>
+<li>Second</li>
+</ol>
+<ul>
+<li>I'm the next</li>
+<li>list element</li>
+</ul>


### PR DESCRIPTION
Hello,

I've noticed that two lists will glue together if one follows another without any divider, such as paragraph, like this:

``` md
1. First
2. Second

* I'm the next
* list element
```

becomes the one list

``` html
<ol>
<li>First</li>
<li>Second</li>
<li>I'm the next</li>
<li>list element</li>
</ul>
```

The fix seems to be quite large, but I couldn't find a better way :(
