### PR TITLE
Emit the html tag attributes sorted.

### DIFF
--- a/lib/Markdent/Role/HTMLStream.pm
+++ b/lib/Markdent/Role/HTMLStream.pm
@@ -623,7 +623,8 @@ sub _attributes {
     my $attr = shift;
 
     return join q{ },
-        map { $self->_attribute( $_, $attr->{$_} ) } keys %{$attr};
+        map { $self->_attribute( $_, $attr->{$_} ) }
+        sort { $a cmp $b } keys %{$attr};
 }
 
 sub _attribute {

--- a/t/Simple/SortedAttributes.t
+++ b/t/Simple/SortedAttributes.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+
+use Markdent::Simple::Fragment;
+
+my $mds = Markdent::Simple::Fragment->new();
+
+my $markdown = <<'EOF';
+A header
+========
+
+<a rel="license" href="https://cpan.org">CPAN with rel</a>
+
+Some *text* with **markup**
+in a paragraph.
+
+* a list
+* with items
+
+That is all
+EOF
+
+my $expect = <<'EOF';
+<h1>A header
+</h1><p><a href="https://cpan.org" rel="license">CPAN with rel</a>
+</p><p>Some <em>text</em> with <strong>markup</strong>
+in a paragraph.
+</p><ul><li>a list
+</li><li>with items
+</li></ul><p>That is all
+</p>
+EOF
+
+chomp $expect;
+
+is(
+    $mds->markdown_to_html( markdown => $markdown ),
+    $expect,
+    'Markdent::Simple::Fragment returns tags with sorted HTML attributes'
+);
+
+done_testing();


### PR DESCRIPTION
For consistent results across runs. See https://reproducible-builds.org/
. Before this changeset, their order was random.