### PR TITLE
support email auto-links without mailto:

### DIFF
--- a/lib/Markdent/Parser/SpanParser.pm
+++ b/lib/Markdent/Parser/SpanParser.pm
@@ -469,10 +469,20 @@ sub _match_delimiter_end {
 sub _match_auto_link {
     my $self = shift;
     my $text = shift;
+    
+    my $uri;
 
-    return unless ${$text} =~ /\G <( (?:https?|mailto|ftp): [^>]+ ) >/xgc;
+    if (${$text} =~ /\G <( (?:https?|mailto|ftp): [^>]+ ) >/xgc) {
+        $uri = $1;
+    }
+    elsif (${$text} =~ /\G <( [^>]+ \@ [^>]+ ) >/xgc) {
+        $uri = "mailto:$1";
+    }
+    else {
+        return;
+    }
 
-    my $link = $self->_make_event( AutoLink => uri => $1 );
+    my $link = $self->_make_event( AutoLink => uri => $uri );
 
     $self->_markup_event($link);
 

--- a/t/markup/standard/link.t
+++ b/t/markup/standard/link.t
@@ -430,6 +430,56 @@ EOF
 
 {
     my $text = <<'EOF';
+An auto link <mailto:foo@bar.com> and more text
+EOF
+
+    my $expect = [
+        { type => 'paragraph' },
+        [
+            {
+                type => 'text',
+                text => 'An auto link ',
+            }, {
+                type => 'auto_link',
+                uri  => 'mailto:foo@bar.com',
+            }, {
+                type => 'text',
+                text => " and more text\n",
+            },
+        ]
+    ];
+
+    parse_ok( $text, $expect, 'text with an email auto link' );
+}
+
+
+{
+    my $text = <<'EOF';
+An auto link <foo@bar.com> and more text
+EOF
+
+    my $expect = [
+        { type => 'paragraph' },
+        [
+            {
+                type => 'text',
+                text => 'An auto link ',
+            }, {
+                type => 'auto_link',
+                uri  => 'mailto:foo@bar.com',
+            }, {
+                type => 'text',
+                text => " and more text\n",
+            },
+        ]
+    ];
+
+    parse_ok( $text, $expect, 'text with an email only auto link' );
+}
+
+
+{
+    my $text = <<'EOF';
 (With outer parens and [parens in url](/foo(bar)))
 EOF
 


### PR DESCRIPTION
Currently following email auto-links do not work:

    <foo@bar.com>

This patch to the parser interprets these as mailto: URLs.