### PR TITLE
avoid new warning in 5.43.2

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Fix code that triggers a warning in Perl 5.43.2+. Implemented by @ether (Karen Etheridge). GH #30.
+
+
 0.40   2021-03-21
 
 - Add support for email auto-links without "mailto:", so "<autarch@urth.org>"

--- a/lib/Markdent/Parser/SpanParser.pm
+++ b/lib/Markdent/Parser/SpanParser.pm
@@ -307,7 +307,7 @@ sub _build_emphasis_start_delimiter_re {
 }
 
 sub _build_escapable_chars {
-    return [ qw( \ ` * _ { } [ ] ( ) + - . ! < > ~ ), '#' ];
+    return [ qw( ` * _ { } [ ] ( ) + - . ! < > ~ ), '\\', '#' ];
 }
 
 sub _build_escape_re {


### PR DESCRIPTION
"Possible attempt to escape whitespace in qw() list at .../Markdent/Parser/SpanParser.pm line 310."